### PR TITLE
update k8s descriptors for k8s 1.16

### DIFF
--- a/01-deathstar.yaml
+++ b/01-deathstar.yaml
@@ -11,11 +11,15 @@ spec:
     org: empire
     class: deathstar
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deathstar
 spec:
+  selector:
+    matchLabels:
+      org: empire
+      class: spaceship
   replicas: 3
   template:
     metadata:
@@ -28,11 +32,15 @@ spec:
         image: docker.io/cilium/starwars:v1.0
         imagePullPolicy: IfNotPresent
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spaceship
 spec:
+  selector:
+    matchLabels:
+      org: empire
+      class: spaceship
   replicas: 4
   template:
     metadata:

--- a/02-xwing.yaml
+++ b/02-xwing.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: xwing
 spec:
+  selector:
+    matchLabels:
+      org: alliance
+      class: spaceship
   replicas: 3
   template:
     metadata:

--- a/cilium-minikube.yaml
+++ b/cilium-minikube.yaml
@@ -67,12 +67,16 @@ subjects:
 - kind: Group
   name: system:nodes
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Since k8s 1.16 removed extensions/v1beta1, we need to update our k8s
descriptors to use the new API, apps/v1

Signed-off-by: André Martins <andre@cilium.io>