### PR TITLE
fix 01-deathstar.yaml deployment selector

### DIFF
--- a/01-deathstar.yaml
+++ b/01-deathstar.yaml
@@ -19,7 +19,7 @@ spec:
   selector:
     matchLabels:
       org: empire
-      class: spaceship
+      class: deathstar
   replicas: 3
   template:
     metadata:


### PR DESCRIPTION
Fixes: a42a4a2d7d9a ("update k8s descriptors for k8s 1.16")
Signed-off-by: André Martins <andre@cilium.io>